### PR TITLE
Fix: fix entity, fix liquibase script, fix exception

### DIFF
--- a/src/main/java/com/jjsttk/goodswarehouse/exception/NotUniqueArticleException.java
+++ b/src/main/java/com/jjsttk/goodswarehouse/exception/NotUniqueArticleException.java
@@ -1,7 +1,15 @@
 package com.jjsttk.goodswarehouse.exception;
 
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
 public class NotUniqueArticleException extends RuntimeException {
-    public NotUniqueArticleException(String message) {
-        super(message);
+    private final UUID productId;
+
+    public NotUniqueArticleException(UUID id) {
+        super(String.format("Product with id %s already uses this article", id));
+        this.productId = id;
     }
 }

--- a/src/main/java/com/jjsttk/goodswarehouse/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/jjsttk/goodswarehouse/exception/ResourceNotFoundException.java
@@ -1,7 +1,15 @@
 package com.jjsttk.goodswarehouse.exception;
 
-public final class ResourceNotFoundException extends RuntimeException {
-    public ResourceNotFoundException(String message) {
-        super(message);
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class ResourceNotFoundException extends RuntimeException {
+    private final UUID resourceId;
+
+    public ResourceNotFoundException(UUID id) {
+        super(String.format("Resource with id = %s not found", id));
+        this.resourceId = id;
     }
 }

--- a/src/main/java/com/jjsttk/goodswarehouse/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/jjsttk/goodswarehouse/exception/handler/GlobalExceptionHandler.java
@@ -73,11 +73,11 @@ public final class GlobalExceptionHandler {
         return buildResponse(status, ex.getMessage(), ex);
     }
 
-    private ResponseEntity<ErrorResponse> buildResponse(HttpStatus status, String customMessage, Exception ex) {
+    private ResponseEntity<ErrorResponse> buildResponse(HttpStatus status, String message, Exception ex) {
         log.error("Handled exception: {}", ex.getClass().getSimpleName(), ex);
 
         ErrorResponse errorResponse = ErrorResponse.builder()
-                .message(customMessage)
+                .message(message)
                 .exception(ex.getClass().getSimpleName())
                 .source(ex.getStackTrace()[0].getClassName())
                 .dateTime(OffsetDateTime.now())

--- a/src/main/java/com/jjsttk/goodswarehouse/persistence/entity/ProductEntity.java
+++ b/src/main/java/com/jjsttk/goodswarehouse/persistence/entity/ProductEntity.java
@@ -26,10 +26,10 @@ import java.util.UUID;
 
 @Entity
 @Table(
-        name = "products",
+        name = "product",
         uniqueConstraints = {
                 @UniqueConstraint(
-                        name = "uk_products_article",
+                        name = "uk_product_article",
                         columnNames = "article"
                 )
         }
@@ -41,16 +41,17 @@ import java.util.UUID;
 @AllArgsConstructor
 @Builder
 @EqualsAndHashCode(of = "article")
-public final class ProductEntity {
+public class ProductEntity {
 
     @Id
     @GeneratedValue
+    @Column(name = "id", updatable = false, nullable = false)
     private UUID id;
 
     @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(name = "article", nullable = false)
+    @Column(name = "article", nullable = false, unique = true)
     private String article;
 
     @Column(name = "description", columnDefinition = "TEXT")

--- a/src/main/java/com/jjsttk/goodswarehouse/service/ProductServiceImpl.java
+++ b/src/main/java/com/jjsttk/goodswarehouse/service/ProductServiceImpl.java
@@ -54,9 +54,7 @@ public class ProductServiceImpl implements ProductService {
     public ProductServiceResponse getById(UUID id) {
         return productRepository.findById(id)
                 .map(productConverter::mapToServiceResponse)
-                .orElseThrow(() -> new ResourceNotFoundException(
-                        String.format("Product with id %s not found", id)
-                ));
+                .orElseThrow(() -> new ResourceNotFoundException(id));
     }
 
     /**
@@ -84,9 +82,7 @@ public class ProductServiceImpl implements ProductService {
         }
 
         var entity = productRepository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException(
-                        String.format("Product with id %s not found", id)
-                ));
+                .orElseThrow(() -> new ResourceNotFoundException(id));
         updateProductEntity(updateCommandDto, entity);
         productRepository.save(entity);
 
@@ -100,9 +96,7 @@ public class ProductServiceImpl implements ProductService {
     @Transactional
     public void delete(UUID id) {
         var productEntity = productRepository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException(
-                        String.format("Product with id %s not found", id)
-                ));
+                .orElseThrow(() -> new ResourceNotFoundException(id));
 
         productRepository.delete(productEntity);
     }
@@ -110,24 +104,14 @@ public class ProductServiceImpl implements ProductService {
     private void checkArticleUnique(String article) {
         var mbProduct = productRepository.findByArticle(article);
         if (mbProduct.isPresent()) {
-            throw new NotUniqueArticleException(
-                    String.format(
-                            "Product with id %s already uses this article",
-                            mbProduct.get().getId()
-                    )
-            );
+            throw new NotUniqueArticleException(mbProduct.get().getId());
         }
     }
 
     private void checkArticleUnique(String article, UUID id) {
         var mbProduct = productRepository.findByArticle(article);
         if (mbProduct.isPresent() && !mbProduct.get().getId().equals(id)) {
-            throw new NotUniqueArticleException(
-                    String.format(
-                            "Product with id %s already uses this article",
-                            mbProduct.get().getId()
-                    )
-            );
+            throw new NotUniqueArticleException(mbProduct.get().getId());
         }
     }
 

--- a/src/main/resources/db/changelog/v1/v1-create-product-table-changelog.xml
+++ b/src/main/resources/db/changelog/v1/v1-create-product-table-changelog.xml
@@ -5,7 +5,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
     <changeSet id="v1-1" author="Konstantinov Aleksandr">
-        <createTable tableName="products">
+        <createTable tableName="product">
             <column name="id" type="UUID">
                 <constraints primaryKey="true"/>
             </column>

--- a/src/test/java/com/jjsttk/goodswarehouse/controller/api/ProductControllerTest.java
+++ b/src/test/java/com/jjsttk/goodswarehouse/controller/api/ProductControllerTest.java
@@ -11,7 +11,6 @@ import com.jjsttk.goodswarehouse.exception.ResourceNotFoundException;
 import com.jjsttk.goodswarehouse.exception.handler.GlobalExceptionHandler;
 import com.jjsttk.goodswarehouse.mapper.ProductConverter;
 import com.jjsttk.goodswarehouse.persistence.entity.ProductEntity;
-import com.jjsttk.goodswarehouse.persistence.repository.ProductRepository;
 import com.jjsttk.goodswarehouse.service.ProductService;
 import com.jjsttk.goodswarehouse.service.command.ProductCreateCommand;
 import com.jjsttk.goodswarehouse.service.command.ProductUpdateCommand;
@@ -58,9 +57,6 @@ class ProductControllerTest {
     private ObjectMapper objectMapper;
 
     @Mock
-    private ProductRepository repositoryMock;
-
-    @Mock
     private ProductConverter converterMock;
 
     @Mock
@@ -102,11 +98,11 @@ class ProductControllerTest {
     void getProductByIdShouldReturn404WhenNotFound() throws Exception {
         var id = controllerResponseStub.id();
         when(productServiceMock.getById(id))
-                .thenThrow(new ResourceNotFoundException("Product not found"));
+                .thenThrow(new ResourceNotFoundException(id));
 
         mockMvc.perform(get("/api/v1/products/{id}", id))
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message").value("Product not found"))
+                .andExpect(jsonPath("$.message").value(String.format("Resource with id = %s not found", id)))
                 .andExpect(jsonPath("$.exception").value("ResourceNotFoundException"))
                 .andExpect(jsonPath("$.source").isNotEmpty())
                 .andExpect(jsonPath("$.dateTime").isNotEmpty());
@@ -149,15 +145,17 @@ class ProductControllerTest {
     @Test
     void createProductShouldReturn409WhenArticleNotUnique() throws Exception {
         var request = controllerRequestStub;
-
+        var id = UUID.randomUUID();
         when(productServiceMock.create(any()))
-                .thenThrow(new NotUniqueArticleException("Article already exists"));
+                .thenThrow(new NotUniqueArticleException(id));
 
         mockMvc.perform(post("/api/v1/products")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.message").value("Article already exists"))
+                .andExpect(jsonPath("$.message").value(
+                        String.format("Product with id %s already uses this article", id)
+                ))
                 .andExpect(jsonPath("$.exception").value("NotUniqueArticleException"))
                 .andExpect(jsonPath("$.source").isNotEmpty())
                 .andExpect(jsonPath("$.dateTime").isNotEmpty());
@@ -179,7 +177,6 @@ class ProductControllerTest {
                 .andExpect(jsonPath("$.source").isNotEmpty())
                 .andExpect(jsonPath("$.dateTime").isNotEmpty());
     }
-
 
 
     @Test
@@ -319,12 +316,12 @@ class ProductControllerTest {
     void deleteProductShouldReturn404WhenNotExists() throws Exception {
         UUID id = UUID.randomUUID();
 
-        doThrow(new ResourceNotFoundException("Product not found"))
+        doThrow(new ResourceNotFoundException(id))
                 .when(productServiceMock).delete(id);
 
         mockMvc.perform(delete("/api/v1/products/{id}", id))
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message").value("Product not found"))
+                .andExpect(jsonPath("$.message").value(String.format("Resource with id = %s not found", id)))
                 .andExpect(jsonPath("$.exception").value("ResourceNotFoundException"));
 
         verify(productServiceMock).delete(id);


### PR DESCRIPTION
1. Entity: убрал модификатор final на сущности Product. Таблица переименована из 'products' в 'product'.
2. Liquibase script: скрипт создающий таблицу исправлен в соответствии с переименованной таблицей в сущности.
3. Exception: NotUniqueArticleException и ResourceNotFoundException теперь не final, так же теперь содержат поле для хранения id продукта связанного с возникшим исключением и геттер. Формирование сообщения теперь происходит в классе исключения, а не в коде где вызывалось исключение с передачей форматированного сообщения об ошибке в качестве параметра. Конструктор позволявший передать сообщение заменен конструктором принимающим параметр id (сохраняет его в приватное поле и использует для формирования сообщения о возникшем исключении). 